### PR TITLE
Revert "Update maxmindinc/geoipupdate Docker tag to v4.10.0"

### DIFF
--- a/infrastructure/docker/containers/authentik/authentik.tf
+++ b/infrastructure/docker/containers/authentik/authentik.tf
@@ -152,7 +152,7 @@ resource "docker_container" "authentik_worker" {
 }
 
 resource "docker_image" "geoip" {
-  name = "maxmindinc/geoipupdate:4.10"
+  name = "maxmindinc/geoipupdate:v4.9"
 }
 
 resource "docker_container" "geoip" {


### PR DESCRIPTION
Reverts flx5/homelab#44

Can not find on docker hub